### PR TITLE
Fix spread averaging logic

### DIFF
--- a/dependencies/DAN4-common1.mqh
+++ b/dependencies/DAN4-common1.mqh
@@ -258,24 +258,25 @@ int subAV_SPREAD() {
 
 
    // add extra storage to array
-   ArrayResize(gSPREAD_ARRAY,fITEMS+1);   
-   
-   
-   
+   ArrayResize(gSPREAD_ARRAY,fITEMS+1);
+
+
+
    // add spread to array
-   gSPREAD_ARRAY[fITEMS+1] = fSPREAD;
-   
-   
+   gSPREAD_ARRAY[fITEMS] = fSPREAD;
+
+
    int fINT=0;
    int fTOTAL=0;
-   
-   
-   for(fINT=0;fINT<fITEMS+1;fINT++)  {
+   int fCOUNT = ArrayRange(gSPREAD_ARRAY,0);
+
+
+   for(fINT=0;fINT<fCOUNT;fINT++)  {
       fTOTAL = fTOTAL + gSPREAD_ARRAY[fINT];
-      } 
-  
-  
-   int fAV_SPREAD = fTOTAL / (fITEMS +1) ; 
+      }
+
+
+   int fAV_SPREAD = fTOTAL / fCOUNT ;
    
    
    


### PR DESCRIPTION
## Summary
- append new spread samples to the end of the cache instead of skipping the last slot
- sum the entire spread history after resizing by caching the new element count

## Testing
- not run (MetaTrader compiler is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddc96b81f08322b6d1f48edbb1c0bd