### PR TITLE
Fix global order count guard for market orders

### DIFF
--- a/dependencies/DAN4-order_info.mqh
+++ b/dependencies/DAN4-order_info.mqh
@@ -16,7 +16,18 @@ void subORDERSTATUS()
    {
       x = OrderSelect(counter,SELECT_BY_POS,MODE_TRADES);
       
-      if ( OrderType() == BUY || OrderType() == SELL ) gGLOBALOPENORDERS++;
+      int orderType = OrderType();
+      if (
+            orderType == OP_BUY ||
+            orderType == OP_SELL
+#ifdef ORDER_TYPE_BUY
+            || orderType == ORDER_TYPE_BUY ||
+            orderType == ORDER_TYPE_SELL
+#endif
+         )
+      {
+         gGLOBALOPENORDERS++;
+      }
       if(OrderSymbol()==Symbol()  )
       {
          if(OrderType()==OP_BUY ) { gBUYTRADES++; gBUYPROFIT = gBUYPROFIT + OrderProfit();  }


### PR DESCRIPTION
## Summary
- update the global order counter in `subORDERSTATUS` to rely on the OP_BUY/OP_SELL constants
- support counting additional market order constants when available

## Testing
- Not run (MetaTrader tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddcd487f68832286d562577d775444